### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing GitHub Skills activity that was announced by the principal and reported by students.

## Related Issue
Fixes #6

## Changes Made
- Added "GitHub Skills" to the activities dictionary in `src/app.py`
- Activity details:
  - **Description**: Learn practical coding and collaboration skills with GitHub. First part of the GitHub Certifications program to help with college applications
  - **Schedule**: Mondays and Thursdays, 3:30 PM - 5:00 PM
  - **Max Participants**: 25 students
  - **Current Participants**: Empty (ready for registration!)

## Testing
- Verified no syntax errors in the Python file
- Activity follows the same structure as existing activities
- Ready for students to sign up through the web interface

## Priority
This is time-sensitive as mentioned in the issue - registrations close by the end of this week. The activity is part of the GitHub Certifications program which helps with college applications.